### PR TITLE
Allow big structures

### DIFF
--- a/Examples/ReadWrite/ReadWrite.ino
+++ b/Examples/ReadWrite/ReadWrite.ino
@@ -107,19 +107,6 @@ void setup() {                                                                //
     FRAM.read(memAddress,testArray);                                          // Read array from 2nd memory       //
     Serial.print(testArray);                                                  //                                  //
     Serial.println("\".");                                                    //                                  //
-
-Serial.println("Test big data strings");
-  char testArray2[65] = "123456789012345678901234567890123456789012345678901234567890abcd";
-  FRAM.write(0,testArray2);
-  Serial.print("Reading from memory chip 2 gives text \"");                 //                                  //
-  FRAM.read(5,testArray2);                                          // Read array from 2nd memory       //
-  Serial.print(testArray2);                                                  //                                  //
-
-
-
-
-
-
   } // of if-then-else we have more than one memory                           //                                  //
   Serial.println("\n\nFinished.");                                            //                                  //
 } // of method setup()                                                        //                                  //
@@ -128,12 +115,3 @@ Serial.println("Test big data strings");
 *******************************************************************************************************************/
 void loop() {                                                                 //                                  //
 } // of method loop()                                                         //----------------------------------//
-
-/*
-  uint32_t memAddress = FRAM.memSize(0)*1024;                               // Set to beginning of 2nd memory   //
-  char testArray2[64] = "1234567890123456789012345678901234567890123456789012345678901234";
-  FRAM.write(memAddress-50,testArray2);
-  Serial.print("Reading from memory chip 2 gives text \"");                 //                                  //
-  FRAM.read(memAddress,testArray);                                          // Read array from 2nd memory       //
-  Serial.print(testArray);                                                  //                                  //
-*/

--- a/Examples/ReadWrite/ReadWrite.ino
+++ b/Examples/ReadWrite/ReadWrite.ino
@@ -25,7 +25,8 @@
 **                                                                                                                **
 ** What sets this library apart is that it will autmatically detect up to 8 memories, in any combination of those **
 ** listed as supported above, and treats them as one contiguous block of memory. The read() and write() functions **
-** also support structures and arrays.                                                                            **
+** also support structures and arrays. Although the internal I2C library has a 32 byte limitation on the buffer   **
+** size, the library allows for larger structures to be read and written.                                         **
 **                                                                                                                **
 ** This program is free software: you can redistribute it and/or modify it under the terms of the GNU General     **
 ** Public License as published by the Free Software Foundation, either version 3 of the License, or (at your      **

--- a/Examples/ReadWrite/ReadWrite.ino
+++ b/Examples/ReadWrite/ReadWrite.ino
@@ -83,7 +83,7 @@ void setup() {                                                                //
   } // of for-next loop                                                       //                                  //
                                                                               //                                  //
   Serial.println("Writing array to memory.");                                 //                                  //
-  char testArray[13] = "Hello Borld!";                                        //                                  //
+  char testArray[13] = "Hello World!";                                        //                                  //
   FRAM.write(200,testArray);                                                  //                                  //
   FRAM.read(200,testArray);                                                   //                                  //
   Serial.print("Read string array as \"");                                    //                                  //
@@ -100,14 +100,26 @@ void setup() {                                                                //
       Serial.println(" bytes.");                                              //                                  //
     } // for-next each memory chip found                                      //                                  //
     Serial.println("\nDemonstrating memory overlapping.");                    //                                  //
-    uint16_t memAddress = FRAM.memSize(0);                                    // Set to beginning of 2nd memory   //
-Serial.print("Using memory size ");Serial.println(memAddress);
+    uint32_t memAddress = FRAM.memSize(0);                                    // Set to beginning of 2nd memory   //
     FRAM.write(memAddress-6,testArray);                                       // Split test string across 2 chips //
     Serial.println("Splitting text write across 2 memory chips.");            //                                  //
     Serial.print("Reading from memory chip 2 gives text \"");                 //                                  //
     FRAM.read(memAddress,testArray);                                          // Read array from 2nd memory       //
     Serial.print(testArray);                                                  //                                  //
     Serial.println("\".");                                                    //                                  //
+
+Serial.println("Test big data strings");
+  char testArray2[65] = "123456789012345678901234567890123456789012345678901234567890abcd";
+  FRAM.write(0,testArray2);
+  Serial.print("Reading from memory chip 2 gives text \"");                 //                                  //
+  FRAM.read(5,testArray2);                                          // Read array from 2nd memory       //
+  Serial.print(testArray2);                                                  //                                  //
+
+
+
+
+
+
   } // of if-then-else we have more than one memory                           //                                  //
   Serial.println("\n\nFinished.");                                            //                                  //
 } // of method setup()                                                        //                                  //

--- a/Examples/ReadWrite/ReadWrite.ino
+++ b/Examples/ReadWrite/ReadWrite.ino
@@ -83,7 +83,7 @@ void setup() {                                                                //
   } // of for-next loop                                                       //                                  //
                                                                               //                                  //
   Serial.println("Writing array to memory.");                                 //                                  //
-  char testArray[13] = "Hello World!";                                        //                                  //
+  char testArray[13] = "Hello Borld!";                                        //                                  //
   FRAM.write(200,testArray);                                                  //                                  //
   FRAM.read(200,testArray);                                                   //                                  //
   Serial.print("Read string array as \"");                                    //                                  //
@@ -100,7 +100,8 @@ void setup() {                                                                //
       Serial.println(" bytes.");                                              //                                  //
     } // for-next each memory chip found                                      //                                  //
     Serial.println("\nDemonstrating memory overlapping.");                    //                                  //
-    uint32_t memAddress = FRAM.memSize(0)*1024;                               // Set to beginning of 2nd memory   //
+    uint16_t memAddress = FRAM.memSize(0);                                    // Set to beginning of 2nd memory   //
+Serial.print("Using memory size ");Serial.println(memAddress);
     FRAM.write(memAddress-6,testArray);                                       // Split test string across 2 chips //
     Serial.println("Splitting text write across 2 memory chips.");            //                                  //
     Serial.print("Reading from memory chip 2 gives text \"");                 //                                  //
@@ -115,3 +116,12 @@ void setup() {                                                                //
 *******************************************************************************************************************/
 void loop() {                                                                 //                                  //
 } // of method loop()                                                         //----------------------------------//
+
+/*
+  uint32_t memAddress = FRAM.memSize(0)*1024;                               // Set to beginning of 2nd memory   //
+  char testArray2[64] = "1234567890123456789012345678901234567890123456789012345678901234";
+  FRAM.write(memAddress-50,testArray2);
+  Serial.print("Reading from memory chip 2 gives text \"");                 //                                  //
+  FRAM.read(memAddress,testArray);                                          // Read array from 2nd memory       //
+  Serial.print(testArray);                                                  //                                  //
+*/

--- a/MB85_FRAM.cpp
+++ b/MB85_FRAM.cpp
@@ -73,7 +73,10 @@ uint8_t MB85_FRAM_Class::begin() {                                            //
           Wire.write(maximumByte);                                            // restore original value           //
           _TransmissionStatus = Wire.endTransmission();                       // Close transmission               //
         } // of if-then-else we've got a wraparound                           //                                  //
-        if (!_I2C[i-MB85_MIN_ADDRESS]) _I2C[i-MB85_MIN_ADDRESS] = 32;         // If none of the above, then 32kB  //
+        if (!_I2C[i-MB85_MIN_ADDRESS]) {                                      // If none of the above, then 32kB  //
+          _I2C[i-MB85_MIN_ADDRESS] = 32;                                      // Set array size                   //
+          _TotalMemory += 32768;                                              // Add value to total               //
+        } // of if-then max memory                                            //                                  //
       } // of for-next loop for each memory size                              //                                  //
       _DeviceCount++;                                                         // Increment the found count        //
     } // of if-then we have found a device                                    //                                  //
@@ -85,7 +88,7 @@ uint8_t MB85_FRAM_Class::begin() {                                            //
 ** Method totalBytes() returns the sum of all the memories found                                                  **
 *******************************************************************************************************************/
 uint32_t MB85_FRAM_Class::totalBytes() {                                      // Return total memory found        //
-  return(_TotalMemory);                                                       // return total bytes               //
+  return _TotalMemory;                                                        // return total bytes               //
 } // of method totalBytes()                                                   //----------------------------------//
 
 /*******************************************************************************************************************
@@ -104,7 +107,6 @@ uint8_t MB85_FRAM_Class::getDevice(uint32_t &memAddress,uint32_t &endAddress){//
      memAddress  -= (uint32_t)_I2C[device] * 1024;                            // adjust memory address            //
     } // of if we have a device at address                                    //                                  //
   } // of for-next all possible devices                                       //                                  //
-Serial.print("memAddress is now ");Serial.println(memAddress);
   return device;                                                              //                                  //
 } // of internal method getDevice()                                           //----------------------------------//
 
@@ -112,7 +114,8 @@ Serial.print("memAddress is now ");Serial.println(memAddress);
 ** Method memSize() returns the device's size in Kb                                                               **
 *******************************************************************************************************************/
 uint16_t MB85_FRAM_Class::memSize(const uint8_t memNumber) {                  // Return memory size in bytes      //
-   if(memNumber<=_DeviceCount) return(_I2C[memNumber]*1024); else return 0;   // Return appropriate value         //
+   if(memNumber<=_DeviceCount) return((uint32_t)_I2C[memNumber]*1024);        // Return appropriate value         //
+                          else return 0;                                      // or zero                          //
 } // of method memSize()                                                      //----------------------------------//   
 
 /*******************************************************************************************************************

--- a/MB85_FRAM.cpp
+++ b/MB85_FRAM.cpp
@@ -104,6 +104,7 @@ uint8_t MB85_FRAM_Class::getDevice(uint32_t &memAddress,uint32_t &endAddress){//
      memAddress  -= (uint32_t)_I2C[device] * 1024;                            // adjust memory address            //
     } // of if we have a device at address                                    //                                  //
   } // of for-next all possible devices                                       //                                  //
+Serial.print("memAddress is now ");Serial.println(memAddress);
   return device;                                                              //                                  //
 } // of internal method getDevice()                                           //----------------------------------//
 

--- a/MB85_FRAM.cpp
+++ b/MB85_FRAM.cpp
@@ -113,3 +113,20 @@ uint8_t MB85_FRAM_Class::getDevice(uint32_t &memAddress,uint32_t &endAddress){//
 uint16_t MB85_FRAM_Class::memSize(const uint8_t memNumber) {                  // Return memory size in bytes      //
    if(memNumber<=_DeviceCount) return(_I2C[memNumber]*1024); else return 0;   // Return appropriate value         //
 } // of method memSize()                                                      //----------------------------------//   
+
+/*******************************************************************************************************************
+** Method requestI2C() is an internal call used in the read() template to send the 2 byte address and request a   **
+** number of bytes to be read from that address                                                                   **
+*******************************************************************************************************************/
+void MB85_FRAM_Class::requestI2C(const uint8_t device,const uint32_t memAddr, // Address device and request data  //
+                                 const uint16_t dataSize,const bool endTrans){//                                  //
+  Wire.beginTransmission(device+MB85_MIN_ADDRESS);                            // Address the I2C device           //
+  Wire.write(memAddr>>8);                                                     // Send MSB register address        //
+  Wire.write((uint8_t)memAddr);                                               // Send LSB address to read         //
+  if (endTrans) {                                                             // Read request, so end transmission//
+    _TransmissionStatus = Wire.endTransmission();                             // Close transmission               //
+    Wire.requestFrom(device+MB85_MIN_ADDRESS, dataSize);                      // Request n-bytes of data          //
+    return Wire.available();                                                  // Return actual bytes read         //
+  } // of if-then endTransmission switch is set                               //                                  //
+  return dataSize;                                                            // Return the dataSize on write     //
+} // of internal method requestI2C()                                          //----------------------------------//

--- a/MB85_FRAM.h
+++ b/MB85_FRAM.h
@@ -34,6 +34,7 @@
 **                                                                                                                **
 ** Vers.  Date       Developer                     Comments                                                       **
 ** ====== ========== ============================= ============================================================== **
+** 1.0.1  2017-09-06 https://github.com/SV-Zanshin Completed testing for large structures                         **
 ** 1.0.1b 2017-09-06 https://github.com/SV-Zanshin Allow structures > 32 bytes, optimized memory use              **
 ** 1.0.0b 2017-09-04 https://github.com/SV-Zanshin Prepared for release, final testing                            **
 ** 1.0.0a 2017-08-27 https://github.com/SV-Zanshin Started coding                                                 **
@@ -75,15 +76,15 @@
         uint32_t endAddress   = 0;                                            // Last address on current memory   //
         uint8_t  device       = getDevice(memAddress,endAddress);             // Compute the actual device to use //
         for (uint8_t i=0;i<structSize;i++) {                                  // loop for each byte to be read    //
-          if(i%BUFFER_LENGTH==0) {                                            // If the buffer is full, then we   //
-            requestI2C(device,memAddress,sizeof(T),true);                     // Get data from memory             //
+          if(i%(BUFFER_LENGTH-2)==0) {                                        // If the buffer is full, then we   //
+            requestI2C(device,memAddress,structSize,true);                    // Get data from memory             //
           } // if our read buffer is full                                     //                                  //
           *bytePtr++ = Wire.read();                                           // Put byte read to pointer address //
           if(memAddress++==endAddress) {                                      // If we've reached the end-of-chip //
             for(uint8_t j=0;j<MB85_MAX_DEVICES;j++) {                         // loop to get the next device      //
               if (device++==MB85_MAX_DEVICES) device = 0;                     // Increment device or start at 0   //
               if (_I2C[device]) {                                             // On a match, address device       //
-                requestI2C(device,0,sizeof(T),true);                          // Get bytes from new memory chip   //
+                requestI2C(device,0,structSize,true);                         // Get bytes from new memory chip   //
                 memAddress = 0;                                               // New memory address               //
                 break;                                                        // And stop looking for a new memory//
               } // of if we've got the next memory                            //                                  //
@@ -99,18 +100,18 @@
         uint32_t memAddress   = addr%_TotalMemory;                            // Ensure no value greater than max //
         uint32_t endAddress   = 0;                                            // Last address on current memory   //
         uint8_t device        = getDevice(memAddress,endAddress);             // Compute the actual device to use //
-        for (uint8_t i=0;i<sizeof(T);i++) {                                   // loop for each byte to be written //
-          if(i%BUFFER_LENGTH==0) {                                            // If the buffer is full, then we   //
-            _TransmissionStatus = Wire.endTransmission();                     // Close transmission               //
-            requestI2C(device,memAddress,sizeof(T),false);                    // Get data from memory             //
-          } // if our read buffer is full                                     //                                  //
+        for (uint8_t i=0;i<structSize;i++) {                                  // loop for each byte to be written //
+          if(i%(BUFFER_LENGTH-2)==0) {                                        // Check if end of buffer reached   //
+            if(i>0) _TransmissionStatus = Wire.endTransmission();             // Close active transmission        //
+            requestI2C(device,memAddress,structSize,false);                   // Position for next buffer data    //
+          } // if our write buffer is full                                    //                                  //
           Wire.write(*bytePtr++);                                             // Write current byte to memory     //
           if(memAddress++==endAddress) {                                      // If we've reached the end-of-chip //
             _TransmissionStatus = Wire.endTransmission();                     // Close transmission               //
             for(uint8_t j=0;j<MB85_MAX_DEVICES;j++) {                         // loop to get the next device      //
               if (device++==MB85_MAX_DEVICES) device = 0;                     // Increment device or start at 0   //
               if (_I2C[device]) {                                             // On a match, address device       //
-                requestI2C(device,0,sizeof(T),false);                         // Position memory pointer to begin //
+                requestI2C(device,0,structSize,false);                        // Position memory pointer to begin //
                 memAddress = 0;                                               // New memory address               //
                 break;                                                        // And stop looking for a new memory//
               } // of if we've got the next memory                            //                                  //

--- a/MB85_FRAM.h
+++ b/MB85_FRAM.h
@@ -83,6 +83,7 @@
             for(uint8_t j=0;j<MB85_MAX_DEVICES;j++) {                         // loop to get the next device      //
               if (device++==MB85_MAX_DEVICES) device = 0;                     // Increment device or start at 0   //
               if (_I2C[device]) {                                             // On a match, address device       //
+Serial.println("!");
                 requestI2C(device,0,sizeof(T),true);                          // Get bytes from new memory chip   //
                 memAddress = 1;                                               // New memory address               //
                 bufferPos  = 0;                                               // read buffer is empty again       //
@@ -90,12 +91,12 @@
               } // of if we've got the next memory                            //                                  //
             } // of for-next loop through each device                         //                                  //
           } // of if-then we've reached the end of the physical memory        //                                  //
-          if(bufferPos==BUFFER_LENGTH) {                                      // If the buffer is full, then we   //
-            bufferPos = 0;                                                    // Reset the buffer position        //
-            requestI2C(device,memAddress,sizeof(T),true);                     // Get bytes from memory            //
-            structSize = Wire.available();                                    // Use the actual number of bytes   //
-            bufferPos  = 0;                                                   // Reset the buffer position        //
-          } // if our read buffer is full                                     //                                  //
+//          if(bufferPos==BUFFER_LENGTH) {                                      // If the buffer is full, then we   //
+//            bufferPos = 0;                                                    // Reset the buffer position        //
+//            requestI2C(device,memAddress,sizeof(T),true);                     // Get bytes from memory            //
+//            structSize = Wire.available();                                    // Use the actual number of bytes   //
+//            bufferPos  = 0;                                                   // Reset the buffer position        //
+//          } // if our read buffer is full                                     //                                  //
         } // of loop for each byte //                                         //                                  //
         return(structSize);                                                   // return the number of bytes read  //
       } // of method read()                                                   //----------------------------------//
@@ -103,12 +104,14 @@
       template<typename T>uint8_t &write(const uint32_t addr,const T &value) {// method to write a structure      //
         const uint8_t* bytePtr = (const uint8_t*)&value;                      // Pointer to structure beginning   //
         uint8_t  structSize   = sizeof(T);                                    // Number of bytes in structure     //
-        uint32_t memAddress   = addr%_TotalMemory;                            // Ensure no value greater than max //
+//        uint32_t memAddress   = addr%_TotalMemory;                            // Ensure no value greater than max //
+        uint32_t memAddress   = addr;                            // Ensure no value greater than max //
         uint32_t endAddress   = 0;                                            // Last address on current memory   //
         uint8_t device        = getDevice(memAddress,endAddress);             // Compute the actual device to use //
         requestI2C(device,memAddress,sizeof(T),false);                        // Position memory pointer          //
         for (uint8_t i=0;i<sizeof(T);i++) {                                   // loop for each byte to be written //
           Wire.write(*bytePtr++);                                             // Write current byte to memory     //
+Serial.print(memAddress);Serial.print(" ");Serial.println(endAddress);
           if(memAddress++==endAddress) {                                      // If we've reached the end-of-chip //
             _TransmissionStatus = Wire.endTransmission();                     // Close transmission               //
             for(uint8_t j=0;j<MB85_MAX_DEVICES;j++) {                         // loop to get the next device      //

--- a/MB85_FRAM.h
+++ b/MB85_FRAM.h
@@ -74,29 +74,21 @@
         uint32_t memAddress   = addr%_TotalMemory;                            // Ensure no value greater than max //
         uint32_t endAddress   = 0;                                            // Last address on current memory   //
         uint8_t  device       = getDevice(memAddress,endAddress);             // Compute the actual device to use //
-        uint8_t  bufferPos    = 0;                                            // Buffer is limited to BUFFER_SIZE //
-        requestI2C(device,memAddress,sizeof(T),true);                         // Get bytes from memory            //
         for (uint8_t i=0;i<structSize;i++) {                                  // loop for each byte to be read    //
+          if(i%BUFFER_LENGTH==0) {                                            // If the buffer is full, then we   //
+            requestI2C(device,memAddress,sizeof(T),true);                     // Get data from memory             //
+          } // if our read buffer is full                                     //                                  //
           *bytePtr++ = Wire.read();                                           // Put byte read to pointer address //
-          bufferPos++;                                                        // Increment the buffer pointer     //
           if(memAddress++==endAddress) {                                      // If we've reached the end-of-chip //
             for(uint8_t j=0;j<MB85_MAX_DEVICES;j++) {                         // loop to get the next device      //
               if (device++==MB85_MAX_DEVICES) device = 0;                     // Increment device or start at 0   //
               if (_I2C[device]) {                                             // On a match, address device       //
-Serial.println("!");
                 requestI2C(device,0,sizeof(T),true);                          // Get bytes from new memory chip   //
-                memAddress = 1;                                               // New memory address               //
-                bufferPos  = 0;                                               // read buffer is empty again       //
+                memAddress = 0;                                               // New memory address               //
                 break;                                                        // And stop looking for a new memory//
               } // of if we've got the next memory                            //                                  //
             } // of for-next loop through each device                         //                                  //
           } // of if-then we've reached the end of the physical memory        //                                  //
-//          if(bufferPos==BUFFER_LENGTH) {                                      // If the buffer is full, then we   //
-//            bufferPos = 0;                                                    // Reset the buffer position        //
-//            requestI2C(device,memAddress,sizeof(T),true);                     // Get bytes from memory            //
-//            structSize = Wire.available();                                    // Use the actual number of bytes   //
-//            bufferPos  = 0;                                                   // Reset the buffer position        //
-//          } // if our read buffer is full                                     //                                  //
         } // of loop for each byte //                                         //                                  //
         return(structSize);                                                   // return the number of bytes read  //
       } // of method read()                                                   //----------------------------------//
@@ -104,21 +96,22 @@ Serial.println("!");
       template<typename T>uint8_t &write(const uint32_t addr,const T &value) {// method to write a structure      //
         const uint8_t* bytePtr = (const uint8_t*)&value;                      // Pointer to structure beginning   //
         uint8_t  structSize   = sizeof(T);                                    // Number of bytes in structure     //
-//        uint32_t memAddress   = addr%_TotalMemory;                            // Ensure no value greater than max //
-        uint32_t memAddress   = addr;                            // Ensure no value greater than max //
+        uint32_t memAddress   = addr%_TotalMemory;                            // Ensure no value greater than max //
         uint32_t endAddress   = 0;                                            // Last address on current memory   //
         uint8_t device        = getDevice(memAddress,endAddress);             // Compute the actual device to use //
-        requestI2C(device,memAddress,sizeof(T),false);                        // Position memory pointer          //
         for (uint8_t i=0;i<sizeof(T);i++) {                                   // loop for each byte to be written //
+          if(i%BUFFER_LENGTH==0) {                                            // If the buffer is full, then we   //
+            _TransmissionStatus = Wire.endTransmission();                     // Close transmission               //
+            requestI2C(device,memAddress,sizeof(T),false);                    // Get data from memory             //
+          } // if our read buffer is full                                     //                                  //
           Wire.write(*bytePtr++);                                             // Write current byte to memory     //
-Serial.print(memAddress);Serial.print(" ");Serial.println(endAddress);
           if(memAddress++==endAddress) {                                      // If we've reached the end-of-chip //
             _TransmissionStatus = Wire.endTransmission();                     // Close transmission               //
             for(uint8_t j=0;j<MB85_MAX_DEVICES;j++) {                         // loop to get the next device      //
               if (device++==MB85_MAX_DEVICES) device = 0;                     // Increment device or start at 0   //
               if (_I2C[device]) {                                             // On a match, address device       //
                 requestI2C(device,0,sizeof(T),false);                         // Position memory pointer to begin //
-                memAddress = 1;                                               // New memory address               //
+                memAddress = 0;                                               // New memory address               //
                 break;                                                        // And stop looking for a new memory//
               } // of if we've got the next memory                            //                                  //
             } // of for-next loop through each device                         //                                  //

--- a/MB85_FRAM.h
+++ b/MB85_FRAM.h
@@ -34,6 +34,7 @@
 **                                                                                                                **
 ** Vers.  Date       Developer                     Comments                                                       **
 ** ====== ========== ============================= ============================================================== **
+** 1.0.1b 2017-09-06 https://github.com/SV-Zanshin Allow structures > 32 bytes, optimized memory use              **
 ** 1.0.0b 2017-09-04 https://github.com/SV-Zanshin Prepared for release, final testing                            **
 ** 1.0.0a 2017-08-27 https://github.com/SV-Zanshin Started coding                                                 **
 **                                                                                                                **
@@ -58,6 +59,7 @@
       uint8_t begin();                                                        // Start using I2C Communications   //
       uint32_t totalBytes();                                                  // Return the total memory available//
       uint16_t memSize(const uint8_t memNumber);                              // Return memory size in bytes      //
+
       /*************************************************************************************************************
       ** Declare the read and write methods as template functions. All device I/O is done through these two       **
       ** functions. If multiple memories have been found they are treated as if they were just one large memory,  **
@@ -71,41 +73,40 @@
         uint8_t  structSize   = sizeof(T);                                    // Number of bytes in structure     //
         uint32_t memAddress   = addr%_TotalMemory;                            // Ensure no value greater than max //
         uint32_t endAddress   = 0;                                            // Last address on current memory   //
-        uint8_t device        = getDevice(memAddress,endAddress);             // Compute the actual device to use //
-        Wire.beginTransmission(device+MB85_MIN_ADDRESS);                      // Address the I2C device           //
-        Wire.write(memAddress>>8);                                            // Send MSB register address        //
-        Wire.write((uint8_t)memAddress);                                      // Send LSB address to read         //
-        _TransmissionStatus = Wire.endTransmission();                         // Close transmission               //
-        Wire.requestFrom(device+MB85_MIN_ADDRESS, sizeof(T));                 // Request n-bytes of data          //
-        structSize = Wire.available();                                        // Use the actual number of bytes   //
+        uint8_t  device       = getDevice(memAddress,endAddress);             // Compute the actual device to use //
+        uint8_t  bufferPos    = 0;                                            // Buffer is limited to BUFFER_SIZE //
+        requestI2C(device,memAddress,sizeof(T),true);                         // Get bytes from memory            //
         for (uint8_t i=0;i<structSize;i++) {                                  // loop for each byte to be read    //
           *bytePtr++ = Wire.read();                                           // Put byte read to pointer address //
+          bufferPos++;                                                        // Increment the buffer pointer     //
           if(memAddress++==endAddress) {                                      // If we've reached the end-of-chip //
             for(uint8_t j=0;j<MB85_MAX_DEVICES;j++) {                         // loop to get the next device      //
               if (device++==MB85_MAX_DEVICES) device = 0;                     // Increment device or start at 0   //
               if (_I2C[device]) {                                             // On a match, address device       //
-                Wire.beginTransmission(device+MB85_MIN_ADDRESS);              // Address the I2C device           //
-                Wire.write((uint8_t)0);                                       // Send MSB register address        //
-                Wire.write((uint8_t)0);                                       // Send LSB address to read         //
-                _TransmissionStatus = Wire.endTransmission();                 // Close transmission               //
-                Wire.requestFrom(device+MB85_MIN_ADDRESS, sizeof(T));         // Request n-bytes of data          //
+                requestI2C(device,0,sizeof(T),true);                          // Get bytes from new memory chip   //
                 memAddress = 1;                                               // New memory address               //
+                bufferPos  = 0;                                               // read buffer is empty again       //
                 break;                                                        // And stop looking for a new memory//
               } // of if we've got the next memory                            //                                  //
             } // of for-next loop through each device                         //                                  //
           } // of if-then we've reached the end of the physical memory        //                                  //
+          if(bufferPos==BUFFER_LENGTH) {                                      // If the buffer is full, then we   //
+            bufferPos = 0;                                                    // Reset the buffer position        //
+            requestI2C(device,memAddress,sizeof(T),true);                     // Get bytes from memory            //
+            structSize = Wire.available();                                    // Use the actual number of bytes   //
+            bufferPos  = 0;                                                   // Reset the buffer position        //
+          } // if our read buffer is full                                     //                                  //
         } // of loop for each byte //                                         //                                  //
         return(structSize);                                                   // return the number of bytes read  //
       } // of method read()                                                   //----------------------------------//
+
       template<typename T>uint8_t &write(const uint32_t addr,const T &value) {// method to write a structure      //
         const uint8_t* bytePtr = (const uint8_t*)&value;                      // Pointer to structure beginning   //
         uint8_t  structSize   = sizeof(T);                                    // Number of bytes in structure     //
         uint32_t memAddress   = addr%_TotalMemory;                            // Ensure no value greater than max //
         uint32_t endAddress   = 0;                                            // Last address on current memory   //
         uint8_t device        = getDevice(memAddress,endAddress);             // Compute the actual device to use //
-        Wire.beginTransmission(device+MB85_MIN_ADDRESS);                      // Address the I2C device           //
-        Wire.write(memAddress>>8);                                            // Send MSB register address        //
-        Wire.write((uint8_t)memAddress);                                      // Send LSB address to read         //
+        requestI2C(device,memAddress,sizeof(T),false);                        // Position memory pointer          //
         for (uint8_t i=0;i<sizeof(T);i++) {                                   // loop for each byte to be written //
           Wire.write(*bytePtr++);                                             // Write current byte to memory     //
           if(memAddress++==endAddress) {                                      // If we've reached the end-of-chip //
@@ -113,9 +114,7 @@
             for(uint8_t j=0;j<MB85_MAX_DEVICES;j++) {                         // loop to get the next device      //
               if (device++==MB85_MAX_DEVICES) device = 0;                     // Increment device or start at 0   //
               if (_I2C[device]) {                                             // On a match, address device       //
-                Wire.beginTransmission(device+MB85_MIN_ADDRESS);              // Address the I2C device           //
-                Wire.write((uint8_t)0);                                       // Send MSB register address        //
-                Wire.write((uint8_t)0);                                       // Send LSB address to read         //
+                requestI2C(device,0,sizeof(T),false);                         // Position memory pointer to begin //
                 memAddress = 1;                                               // New memory address               //
                 break;                                                        // And stop looking for a new memory//
               } // of if we've got the next memory                            //                                  //
@@ -127,6 +126,8 @@
       } // of method write()                                                  //----------------------------------//
     private:                                                                  // -------- Private methods ------- //
       uint8_t getDevice(uint32_t &memAddress, uint32_t &endAddress);          // Compute actual device to use     //
+      void    requestI2C(const uint8_t device,const uint32_t memAddress,      // Address device and request data  //
+                         const uint16_t dataSize, const bool endTrans);       //                                  //
       uint8_t  _DeviceCount           =     0;                                // Number of memories found         //
       uint32_t _TotalMemory           =     0;                                // Number of bytes in total         //
       uint8_t  _I2C[MB85_MAX_DEVICES] =   {0};                                // List of device kB capacities     //


### PR DESCRIPTION
Allow reading and writing variables greater than 30 bytes (I2C buffer is 32 bytes, but 2 bytes are used to store the address)